### PR TITLE
Minimal changes needed to get eval to work with FAIR 3P o1-mini deployment

### DIFF
--- a/gg_bench/utils/chat_completion/azure_openai_chat_completion.py
+++ b/gg_bench/utils/chat_completion/azure_openai_chat_completion.py
@@ -1,0 +1,44 @@
+
+import openai
+import os
+from openai import AzureOpenAI
+
+# Local Imports
+from gg_bench.utils.chat_completion.openai_chat_completion import OpenAIChatCompletion, OpenAIConfigError
+from gg_bench.utils.chat_completion.utils import find_config_file
+from gg_bench.utils.load_yaml import load_yaml
+
+OPENAI_CONFIG_FILE = "openai_config.yaml"
+
+class AzureOpenAIChatCompletion(OpenAIChatCompletion):
+    def __init__(
+        self, model: str, base_url: str | None = None, api_key: str | None = None
+    ):
+        self.model = model
+
+        openai_config_path = find_config_file(
+            config_file=OPENAI_CONFIG_FILE,
+            exception_to_raise=OpenAIConfigError,
+            exception_message="OpenAI config not found",
+        )
+        config = load_yaml(openai_config_path)
+        config = config.get("azure_openai", config)
+
+        api_key = config.get("api_key", api_key)
+        openai.api_key = api_key
+        os.environ["OPENAI_API_KEY"] = api_key
+
+        api_version = config.get("api_version", None)
+
+        azure_endpoint = config.get("endpoint", base_url)
+
+        self.client = openai.AzureOpenAI(
+            api_key=api_key,
+            api_version=api_version,
+            azure_endpoint=azure_endpoint,
+        )
+        self.async_client = openai.AsyncAzureOpenAI(
+            api_key=api_key,
+            api_version=api_version,
+            azure_endpoint=azure_endpoint,
+        )


### PR DESCRIPTION
Along with the code changes in the PR, do : 
1. place __init__.py inside gg_bench
2. pip install --upgrade "jax[cuda12_pip]==0.5.1" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
3. create your own appropriate openai_config.yaml with appropriate key and endpoint

Running it (tried two things) : 
1. `gg-bench eval --id_range 272 272 --model o1-mini`
2. `gg-bench eval --id_range 707 773 --model o1-mini`